### PR TITLE
Refactor: Improve calling convention adherence in helper_fn

### DIFF
--- a/Lab/lab03/cc_test.s
+++ b/Lab/lab03/cc_test.s
@@ -152,17 +152,17 @@ inc_arr_end:
 # as appropriate.
 helper_fn:
     # BEGIN PROLOGUE
-    addi sp, sp, -8
-    sw t1, 0(sp)
-    sw s0, 4(sp)
+    addi sp, sp, -4
+    sw s0, 0(sp)
     # END PROLOGUE
+
     lw t1, 0(a0)
     addi s0, t1, 1
     sw s0, 0(a0)
+    
     # BEGIN EPILOGUE
-    lw s0, 4(sp)
-    lw t1, 0(sp)
-    addi sp, sp, 8
+    lw s0, 0(sp)
+    addi sp, sp, 4
     # END EPILOGUE
     ret
 


### PR DESCRIPTION
Hello，

我注意到在 helper_fn 中，寄存器t1被保存到堆栈中，并在函数的序言和结尾处恢复。

根据 RISC-V Calling Convention，t1属于“caller-saver”。我建议删除 t1，以便于使用本repo为参考的cs61c的学习者更好地理解 RISC-V 寄存器的调用约定。